### PR TITLE
feat: remove the retweets that include likes `@SaveToNotion`

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,11 +45,25 @@
     return ref
   }
 
+  function iDoNotWantToSeeWhereYouSaveTo(keys) {
+    keys.forEach((key) => {
+      const nodes = document.querySelectorAll('div[data-testid=\'cellInnerDiv\']')
+      if (nodes && nodes.length) {
+        const divs = Array.from(nodes)
+        divs.filter(el => el.textContent.includes(key)).forEach(div => div.classList.add('must-hide'))
+      }
+    })
+  }
+
   const hideHomeTabs = useOption('twitter_hide_home_tabs', 'Hide Home Tabs', true)
   const hideBlueBadge = useOption('twitter_hide_blue_badge', 'Hide Blue Badges', true)
+  const hideSaveTo = useOption('twitter_hide_save_to', 'Hide RT of SaveTo', true)
 
+  let checkSaveToTimer = 0
+  const mustHide = ['@SaveToNotion', '@savetonotion', '@readwise', '@threadreaderapp', '@SaveToBookmarks']
   const style = document.createElement('style')
   const hides = [
+    '.must-hide',
     // menu
     '[aria-label="Communities (New items)"], [aria-label="Communities"], [aria-label="Twitter Blue"], [aria-label="Timeline: Trending now"], [aria-label="Who to follow"], [aria-label="Search and explore"], [aria-label="Verified Organizations"]',
     // submean
@@ -81,6 +95,17 @@
           if (tabs.length === 2 && tabs[1].getAttribute('aria-selected') === 'false')
             tabs[1].click()
         }
+      }, 500)
+    })
+  }
+  
+  if (hideSaveTo.value) {
+    window.addEventListener('load', () => {
+      checkSaveToTimer = setInterval(() => {
+        if (hideSaveTo.value)
+          iDoNotWantToSeeWhereYouSaveTo(mustHide)
+        else
+          checkSaveToTimer && clearInterval(checkSaveToTimer)
       }, 500)
     })
   }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
I want to remove some meaningless retweets, such as those mentioning `@SaveToNotion` or `@readwise`. 


### Additional context

I feel using the `setInterval` method is not very well, but i can't think of a bettery way.
-----
<a href="https://stackblitz.com/~/github.com/LarchLiu/userscript-clean-twitter/tree/main"><img src="https://developer.stackblitz.com/img/review_pr_small.svg" alt="Review PR in StackBlitz Codeflow" align="left" width="103" height="20"></a> _Submitted with [StackBlitz Codeflow](https://stackblitz.com/~/github.com/LarchLiu/userscript-clean-twitter/tree/main)._