### PR TITLE
fix: hide trending child

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@
     // submean
     '* > [href="/i/verified-orgs-signup"]',
     // sidebar
-    '[aria-label="Trending"] > * > *:nth-child(3), [aria-label="Trending"] > * > *:nth-child(4)',
+    '[aria-label="Trending"] > * > *:nth-child(3), [aria-label="Trending"] > * > *:nth-child(4), [aria-label="Trending"] > * > *:nth-child(5)',
     // "Verified" tab
     '[role="presentation"]:has(> [href="/notifications/verified"][role="tab"])',
     // verified badge


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Currently twitter trending section adding a new section.
The 3, 4, 5 child should be hide.

<img src="https://github.com/antfu/userscript-clean-twitter/assets/54026110/28debc63-cbb0-4e3c-ad22-87dd4fad804f" width="300" />

<img src="https://github.com/antfu/userscript-clean-twitter/assets/54026110/4ee344d7-b174-44ec-82b5-b74288450f83" width="300" />


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

none


### Additional context

none

<!-- e.g. is there anything you'd like reviewers to focus on? -->
